### PR TITLE
moved to xeus3 stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ set(nlohmann_json_REQUIRED_VERSION 3.2.0)
 set(xtl_REQUIRED_VERSION 0.7)
 set(cppzmq_REQUIRED_VERSION 4.4.1)
 set(zeromq_REQUIRED_VERSION 4.3.2)
-
+set(xeus_zmq_REQUIRED_VERSION 1.0.2)
+set(xeus_REQUIRED_VERSION 3.0.3)
 # Compilation options
 option(XQ_DISABLE_ARCH_NATIVE "disable -march=native flag" OFF)
 option(XQ_BUILD_SHARED_LIBS "Build XQ shared library." ON)
@@ -57,7 +58,11 @@ message(STATUS "xq binary version: v${XQ_BINARY_VERSION}")
 find_package(Qt5 COMPONENTS Core REQUIRED)
 
 if (NOT TARGET xeus AND NOT TARGET xeus-static)
-    find_package(xeus ${xeus_REQUIRED_VERSION} REQUIRED)
+    find_package(xeus     ${xeus_REQUIRED_VERSION} REQUIRED)
+endif ()
+
+if (NOT TARGET xeus-zmq AND NOT TARGET xeus-zmq-static)
+    find_package(xeus-zmq ${xeus_zmq_REQUIRED_VERSION} REQUIRED)
 endif ()
 
 if (NOT TARGET nlohmann_json)
@@ -162,6 +167,7 @@ macro(xq_create_target target_name linkage output_name)
         PUBLIC nlohmann_json::nlohmann_json
         PUBLIC xtl
         PUBLIC xeus
+        PUBLIC xeus-zmq
         PUBLIC Qt5::Core
     )
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ZeroMQ-based middleware for xeus integrated in the Qt event loop.
 Qt is always refering to Qt5.
 
 ```
-mamba install compilers cmake pkg-config zeromq cppzmq xtl OpenSSL nlohmann_json qt=5.12.9 xeus=2.1.1 -c conda-forge
+mamba install compilers cmake pkg-config zeromq cppzmq xtl OpenSSL nlohmann_json qt=5.12.9 xeus=3.0.3 xeus-zmq=1.0.2  -c conda-forge
 ```
 
 To run the example:

--- a/include/xq/xq_qt_poller.hpp
+++ b/include/xq/xq_qt_poller.hpp
@@ -6,7 +6,7 @@
 #include "zmq_addon.hpp"
 
 #include "xeus/xmessage.hpp"
-#include "xeus/xauthentication.hpp"
+#include "xeus-zmq/xauthentication.hpp"
 #include "xeus/xkernel_configuration.hpp"
 
 #include <iostream>

--- a/include/xq/xq_server.hpp
+++ b/include/xq/xq_server.hpp
@@ -7,7 +7,7 @@
 #include "zmq_addon.hpp"
 
 #include <xeus/xmessage.hpp>
-#include <xeus/xserver_zmq.hpp>
+#include <xeus-zmq/xserver_zmq.hpp>
 #include <xeus/xkernel_configuration.hpp>
 
 #include "xq/xq_qt_poller.hpp"

--- a/src/xq_qt_poller.cpp
+++ b/src/xq_qt_poller.cpp
@@ -1,8 +1,8 @@
 #include "xq/xq_qt_poller.hpp"
 
-#include "xeus/xserver_zmq.hpp"
-#include "xeus/xzmq_serializer.hpp"
-#include "xeus/xmiddleware.hpp"
+#include "xeus-zmq/xserver_zmq.hpp"
+#include "xeus-zmq/xzmq_serializer.hpp"
+#include "xeus-zmq/xmiddleware.hpp"
 
 #include <zmq_addon.hpp>
 

--- a/src/xq_server.cpp
+++ b/src/xq_server.cpp
@@ -4,8 +4,8 @@
 
 #include <zmq_addon.hpp>
 
-#include <xeus/xserver_zmq.hpp>
-#include "xeus/xzmq_serializer.hpp"
+#include <xeus-zmq/xserver_zmq.hpp>
+#include "xeus-zmq/xzmq_serializer.hpp"
 
 #include "xq/xq_server.hpp"
 #include "xq/xq_qt_poller.hpp"


### PR DESCRIPTION
- using `xeus>=3` 
- added `xeus-zmq` as a dependency
- swapped the needed include statemtns from `#include "xeux/...."` to `#include  "xeus-zmq/..."`
- added link to `xeus-zmq`